### PR TITLE
Added extras_require

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,5 +220,6 @@ Very useful when we collect data from an API which uses _camelCase_ for its keys
 The tests passed successfully with **Python 3.6**. With **Python 2.7** fail on "bytes stuff" tests, regarding the use of the static method **from_json()**.
 
 ```shell
+$ pip install pytest
 $ pytest mydict -v
 ```

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,10 @@ setup(
     ],
     install_requires=[
         'stringcase',
-        'pytest',
-    ]
+    ],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
 )

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+pip install pytest
 pytest mydict -v


### PR DESCRIPTION
Install with pytest:
```
$ pip install mydict[test]
```
It wil be good if exclude any tests from binary package too